### PR TITLE
Add support to setup Keystone services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,4 +17,5 @@ openstack_keystone_projects: []
 openstack_keystone_users: []
 openstack_keystone_roles: []
 openstack_keystone_user_roles: []
+openstack_keystone_services: []
 ...

--- a/molecule.yml
+++ b/molecule.yml
@@ -22,6 +22,10 @@ ansible:
           - user: demo
             role: user
             project: demo
+        openstack_keystone_services:
+          - name: glance
+            type: image
+            description: 'Image Service'
 dependency:
   name: galaxy
   requirements_file: tests/requirements.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,6 +63,13 @@
       role: "{{ item.role }}"
       project: "{{ item.project }}"
     with_items: "{{ openstack_keystone_user_roles }}"
+  - name: create services
+    os_keystone_service:
+      state: "{{ item.state | default(omit) }}"
+      name: "{{ item.name }}"
+      service_type: "{{ item.type }}"
+      description: "{{ item.description }}"
+    with_items: "{{ openstack_keystone_services }}"
 
   environment:
     OS_USERNAME: "{{ openstack_keystone_admin_username }}"


### PR DESCRIPTION
This patch adds support for this role to automatically setup
Keystone services by using `openstack_keystone_services`.