### PR TITLE
Removed RDO dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Dependencies
 ------------
 This role has the following dependencies:
 
-- `vexxhost.openstack-rdo`
+- `vexxhost.openstack-oslo`
 
 All of those are included as part of the role so they should be included
-automatically when installing via Galaxy.
+automatically when installing via Galaxy.  If you need to install from RDO,
+it's suggested that you add the `vexxhost.openstack-rdo` role to automatically
+install the repos.
 
 
 Example Playbook

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,5 +17,4 @@ galaxy_info:
 
 
 dependencies:
-  - vexxhost.openstack-rdo
   - vexxhost.openstack-oslo

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -25,6 +25,7 @@
 
 - hosts: all
   roles:
+    - role: vexxhost.openstack-rdo
     - role: ansible-role-openstack-keystone
   tags:
     - keystone


### PR DESCRIPTION
This makes the Ansible role hardcoded with RDO, down the road it would be nice for it to support other operating systems.

In addition, this allows more control if you want to install from a different package source.